### PR TITLE
一覧画面とCSVダウンロードのページネーション化

### DIFF
--- a/apps/backend/src/handlers/getAccessJudgmentUrls.ts
+++ b/apps/backend/src/handlers/getAccessJudgmentUrls.ts
@@ -5,6 +5,7 @@ import {
 	getAccessJudgmentUrls,
 	getAccessJudgmentUrlsByBaseUrlIds,
 	getAccessJudgmentUrlsByCompanyIds,
+	getAccessJudgmentUrlsCount,
 } from "~/models/accessJudgmentUrl";
 import { getAccessJudgmentUrlLogsByAccessJudgmentUrlId } from "~/models/accessJudgmentUrlLog";
 import { getBaseUrlById, getBaseUrlsByUrlLike } from "~/models/baseUrl";
@@ -54,6 +55,8 @@ export const getAccessJudgmentUrlsHandler: RouteHandler<
 				)
 			: await getAccessJudgmentUrls(db, limit, offset, sort, order);
 
+	const totalCount = await getAccessJudgmentUrlsCount(db);
+
 	const response: GetAccessJudgmentUrlsResponse = {
 		accessJudgmentUrls: await Promise.all(
 			accessJudgmentUrlRecords.map(async (accessJudgmentUrlRecord) => {
@@ -100,6 +103,7 @@ export const getAccessJudgmentUrlsHandler: RouteHandler<
 				};
 			}),
 		),
+		totalCount,
 	};
 
 	return c.json(response, 200);

--- a/apps/backend/src/models/accessJudgmentUrl.ts
+++ b/apps/backend/src/models/accessJudgmentUrl.ts
@@ -66,6 +66,13 @@ export const getAccessJudgmentUrls = async (
 	});
 };
 
+export const getAccessJudgmentUrlsCount = async (
+	db: D1Database,
+): Promise<number> => {
+	const prismaClient = createPrismaClientWithD1(db);
+	return await prismaClient.accessJudgmentUrl.count();
+};
+
 export const getAccessJudgmentUrlsByCompanyIds = async (
 	db: D1Database,
 	limit: number,

--- a/apps/backend/src/schema/accessJudgmentUrl.ts
+++ b/apps/backend/src/schema/accessJudgmentUrl.ts
@@ -92,6 +92,9 @@ export const getAccessJudgmentUrlsResponseSchema = z.object({
 			}),
 		}),
 	),
+	totalCount: z.number().openapi({
+		description: "アクセス判定URLの総数",
+	}),
 });
 
 export const viewAccessJudgmentUrlParamsSchema = z.object({

--- a/apps/frontend/src/constants/index.ts
+++ b/apps/frontend/src/constants/index.ts
@@ -8,5 +8,6 @@ export const ROUTES = {
 } as const;
 export const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
 export const TOAST_DURATION = 3000;
+export const ITEMS_PER_PAGE = 50;
 
 export type Routes = (typeof ROUTES)[keyof typeof ROUTES];

--- a/apps/frontend/src/features/DisplayAccessJudgmentDetails/components/DownloadingDialog/index.tsx
+++ b/apps/frontend/src/features/DisplayAccessJudgmentDetails/components/DownloadingDialog/index.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import styles from "./style.module.scss";
+
+export const DownloadingDialog = (): ReactNode => {
+	return (
+		<>
+			<div className={styles["overlay"]} />
+			<div className={styles["downloading-dialog"]}>
+				<p className={styles["downloading-dialog-text"]}>ダウンロード中...</p>
+			</div>
+		</>
+	);
+};

--- a/apps/frontend/src/features/DisplayAccessJudgmentDetails/components/DownloadingDialog/style.module.scss
+++ b/apps/frontend/src/features/DisplayAccessJudgmentDetails/components/DownloadingDialog/style.module.scss
@@ -1,0 +1,26 @@
+.downloading-dialog {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  display: grid;
+  align-items: center;
+  padding: 30px;
+  background-color: #fff;
+  border-radius: 10px;
+  transform: translate(-50%, -50%);
+
+  .downloading-dialog-text {
+    font-size: 20px;
+    font-weight: bold;
+    text-align: center;
+  }
+}
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgb(0 0 0 / 50%);
+}

--- a/apps/frontend/src/features/DisplayAccessJudgmentDetails/components/PaginationAction/index.tsx
+++ b/apps/frontend/src/features/DisplayAccessJudgmentDetails/components/PaginationAction/index.tsx
@@ -1,0 +1,37 @@
+import { Button } from "@/components/Button";
+import type { ReactNode } from "react";
+import styles from "./style.module.scss";
+
+type Props = {
+	currentPage: number;
+	totalPages: number;
+	onPageChange: (page: number) => void;
+};
+
+export const PaginationAction = ({
+	currentPage,
+	totalPages,
+	onPageChange,
+}: Props): ReactNode => {
+	return (
+		<div className={styles["pagination-container"]}>
+			<Button
+				text="前へ"
+				onClick={() => onPageChange(currentPage - 1)}
+				size="xs"
+				isOutline={true}
+				isDisable={currentPage === 1}
+			/>
+			<p className={styles["page-number"]}>
+				{currentPage}/{totalPages}
+			</p>
+			<Button
+				text="次へ"
+				onClick={() => onPageChange(currentPage + 1)}
+				size="xs"
+				isOutline={true}
+				isDisable={currentPage === totalPages}
+			/>
+		</div>
+	);
+};

--- a/apps/frontend/src/features/DisplayAccessJudgmentDetails/components/PaginationAction/style.module.scss
+++ b/apps/frontend/src/features/DisplayAccessJudgmentDetails/components/PaginationAction/style.module.scss
@@ -1,0 +1,10 @@
+.pagination-container {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  justify-content: center;
+
+  .page-number {
+    font-size: $font-size-sm;
+  }
+}

--- a/apps/frontend/src/features/DisplayAccessJudgmentDetails/components/index.module.scss
+++ b/apps/frontend/src/features/DisplayAccessJudgmentDetails/components/index.module.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: $gap-lg;
+  padding-bottom: $gap-lg;
 
   .access-judgment-url-actions {
     display: flex;

--- a/apps/frontend/src/features/DisplayAccessJudgmentDetails/components/index.tsx
+++ b/apps/frontend/src/features/DisplayAccessJudgmentDetails/components/index.tsx
@@ -1,14 +1,20 @@
 import { Button } from "@/components/Button";
+import { useDownloadCsv } from "../hooks/useDownloadCsv";
 import { useSearchQuery } from "../hooks/useSearchQuery";
 import { AccessJudgmentUrlDetailsTable } from "./AccessJudgmentUrlDetailsTable";
 import { AccessJudgmentUrlSearchBar } from "./AccessJudgmentUrlSearchBar";
-
-import { useDownloadCsv } from "../hooks/useDownloadCsv";
+import { PaginationAction } from "./PaginationAction";
 import styles from "./index.module.scss";
 
 export function AccessJudgmentUrlSearchTable() {
-	const { accessJudgmentUrlsDetails, onChangeSearchQuery, handleSearch } =
-		useSearchQuery();
+	const {
+		accessJudgmentUrlsDetails,
+		onChangeSearchQuery,
+		handleSearch,
+		handlePageChange,
+		currentPage,
+		totalPages,
+	} = useSearchQuery();
 
 	const handleDownloadCsv = useDownloadCsv();
 
@@ -30,6 +36,13 @@ export function AccessJudgmentUrlSearchTable() {
 			<div className={styles["access-judgment-url-details-list"]}>
 				<AccessJudgmentUrlDetailsTable
 					accessJudgmentUrlsDetails={accessJudgmentUrlsDetails}
+				/>
+			</div>
+			<div className={styles["pagination-container"]}>
+				<PaginationAction
+					currentPage={currentPage}
+					totalPages={totalPages}
+					onPageChange={handlePageChange}
 				/>
 			</div>
 		</div>

--- a/apps/frontend/src/features/DisplayAccessJudgmentDetails/components/index.tsx
+++ b/apps/frontend/src/features/DisplayAccessJudgmentDetails/components/index.tsx
@@ -3,12 +3,14 @@ import { useDownloadCsv } from "../hooks/useDownloadCsv";
 import { useSearchQuery } from "../hooks/useSearchQuery";
 import { AccessJudgmentUrlDetailsTable } from "./AccessJudgmentUrlDetailsTable";
 import { AccessJudgmentUrlSearchBar } from "./AccessJudgmentUrlSearchBar";
+import { DownloadingDialog } from "./DownloadingDialog";
 import { PaginationAction } from "./PaginationAction";
 import styles from "./index.module.scss";
 
 export function AccessJudgmentUrlSearchTable() {
 	const {
 		accessJudgmentUrlsDetails,
+		searchQuery,
 		onChangeSearchQuery,
 		handleSearch,
 		handlePageChange,
@@ -16,7 +18,10 @@ export function AccessJudgmentUrlSearchTable() {
 		totalPages,
 	} = useSearchQuery();
 
-	const handleDownloadCsv = useDownloadCsv();
+	const { handleDownloadCsv, isDownloading } = useDownloadCsv(
+		searchQuery,
+		totalPages,
+	);
 
 	return (
 		<div className={styles["access-judgment-url-search-table"]}>
@@ -27,8 +32,8 @@ export function AccessJudgmentUrlSearchTable() {
 				/>
 				<Button
 					text="CSV出力"
-					onClick={() => {
-						handleDownloadCsv(accessJudgmentUrlsDetails);
+					onClick={async () => {
+						await handleDownloadCsv();
 					}}
 					isDisable={!accessJudgmentUrlsDetails}
 				/>
@@ -45,6 +50,7 @@ export function AccessJudgmentUrlSearchTable() {
 					onPageChange={handlePageChange}
 				/>
 			</div>
+			{isDownloading && <DownloadingDialog />}
 		</div>
 	);
 }

--- a/apps/frontend/src/features/DisplayAccessJudgmentDetails/hooks/useSearchQuery.ts
+++ b/apps/frontend/src/features/DisplayAccessJudgmentDetails/hooks/useSearchQuery.ts
@@ -1,3 +1,4 @@
+import { ITEMS_PER_PAGE } from "@/constants";
 import type { GetAccessJudgmentUrlsResponse } from "@/types/scheme";
 import { type ChangeEvent, useEffect, useState } from "react";
 import { getAccessJudgmentUrlDetails } from "../api/getAccessJudgmentUrlDetails";
@@ -8,13 +9,22 @@ export function useSearchQuery() {
 	const [searchQuery, setSearchQuery] = useState("");
 	const [isLoading, setIsLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
+	const [currentPage, setCurrentPage] = useState(1);
+	const [totalPages, setTotalPages] = useState(1);
 
 	useEffect(() => {
 		const fetchData = async () => {
 			try {
 				setIsLoading(true);
-				const response = await getAccessJudgmentUrlDetails();
+				const response = await getAccessJudgmentUrlDetails(
+					searchQuery,
+					"",
+					"",
+					ITEMS_PER_PAGE,
+					(currentPage - 1) * ITEMS_PER_PAGE,
+				);
 				setAccessJudgmentUrlsDetails(response);
+				setTotalPages(Math.ceil(response.totalCount / ITEMS_PER_PAGE));
 			} catch (err) {
 				setError(err instanceof Error ? err.message : "エラーが発生しました");
 			} finally {
@@ -23,7 +33,7 @@ export function useSearchQuery() {
 		};
 
 		fetchData();
-	}, []);
+	}, [currentPage, searchQuery]);
 
 	const onChangeSearchQuery = (e: ChangeEvent<HTMLInputElement>) => {
 		setSearchQuery(e.target.value);
@@ -42,6 +52,10 @@ export function useSearchQuery() {
 		}
 	};
 
+	const handlePageChange = (newPage: number) => {
+		setCurrentPage(newPage);
+	};
+
 	return {
 		error,
 		isLoading,
@@ -49,5 +63,8 @@ export function useSearchQuery() {
 		accessJudgmentUrlsDetails,
 		handleSearch,
 		onChangeSearchQuery,
+		handlePageChange,
+		currentPage,
+		totalPages,
 	};
 }

--- a/apps/frontend/src/types/scheme.d.ts
+++ b/apps/frontend/src/types/scheme.d.ts
@@ -39,4 +39,5 @@ export type GetAccessJudgmentUrlsResponse = {
 			viewedAts: number[];
 		};
 	}[];
+	totalCount: number;
 };


### PR DESCRIPTION
## チケットへのリンク

## やったこと
一覧画面とCSVダウンロードをページネーション取得するようにしました
CSVダウンロードは件数が多いと時間がかかるためダウンロード中はダイアログが表示されます

<img width="500" alt="スクリーンショット 2025-06-13 13 57 04" src="https://github.com/user-attachments/assets/684256de-38ac-45a7-8fc8-6d67c1d5fa83" />

<img width="500" alt="スクリーンショット 2025-06-13 13 57 23" src="https://github.com/user-attachments/assets/453029b3-7fb6-4782-9ee5-cf41acf8b856" />


## やらないこと

## 実行結果

## レビューポイント

## その他
